### PR TITLE
Add Janitor Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See [DSpace Docker Tutorial](tutorial.md)
 ### Service Specific Images
 - [dspace-codenvy-tomcat](dspace-codenvy-tomcat)
   - [dspace/dspace-codenvy-tomcat](https://hub.docker.com/r/dspace/dspace-codenvy-tomcat/)
-- dspace-janitor-angular
+- [dspace-janitor-angular](dspace-janitor-angular)
 
 ## Planned Docker Compose Configurations
 _The management of docker compose images is TBD_

--- a/dspace-janitor-angular/dspace-update.dockerfile
+++ b/dspace-janitor-angular/dspace-update.dockerfile
@@ -1,0 +1,13 @@
+FROM janitortechnology/dspace
+
+# Upgrade all packages.
+RUN sudo apt-get update -q && sudo apt-get upgrade -qy
+
+# Update DSpace's source code and its dependencies.
+RUN cd /home/user/dspace \
+  && git fetch origin \
+  && git reset --hard origin/master \
+  && yarn run clean \
+  && yarn install \
+  && yarn prestart
+  

--- a/dspace-janitor-angular/dspace.dockerfile
+++ b/dspace-janitor-angular/dspace.dockerfile
@@ -1,0 +1,25 @@
+FROM janitortechnology/ubuntu-dev
+
+# Get source code
+RUN git clone https://github.com/dspace/dspace-angular /home/user/dspace-angular/
+WORKDIR /home/user/dspace-angular/
+
+# Add server configuration
+COPY environment.prod.js /home/user/dspace-angular/config/
+RUN sudo chown user:user /home/user/dspace-angular/config/environment.prod.js
+
+# Install dependencies
+RUN yarn run global \
+  && yarn install \
+  && yarn prestart
+
+# Add Janitor configurations
+COPY janitor.json /home/user/
+RUN sudo chown user:user /home/user/janitor.json
+
+# Configure the IDEs to use Janitor's source directory as workspace.
+ENV WORKSPACE /home/user/dspace-angular/
+
+# For DSpace Angular
+EXPOSE 3000
+

--- a/dspace-janitor-angular/environment.prod.js
+++ b/dspace-janitor-angular/environment.prod.js
@@ -1,0 +1,35 @@
+module.exports = {
+  // Angular Universal server settings.
+  ui: {
+    ssl: false,
+    host: '0.0.0.0',
+    port: 3000,
+    // NOTE: Space is capitalized because 'namespace' is a reserved string in TypeScript
+    nameSpace: '/'
+  },
+  // The REST API server settings.
+  rest: {
+    ssl: true,
+    host: 'dspace7.4science.it',
+    port: 443,
+    // NOTE: Space is capitalized because 'namespace' is a reserved string in TypeScript
+    nameSpace: '/dspace-spring-rest/api'
+  },
+  // Caching settings
+  cache: {
+    // NOTE: how long should objects be cached for by default
+    msToLive: 15 * 60 * 1000, // 15 minute
+    control: 'max-age=60' // revalidate browser
+  },
+  // Angular Universal settings
+  universal: {
+    preboot: true,
+    async: true,
+    time: false
+  },
+  // Log directory
+  logDirectory: '.',
+  // NOTE: will log all redux actions and transfers in console
+  debug: false
+};
+

--- a/dspace-janitor-angular/janitor.json
+++ b/dspace-janitor-angular/janitor.json
@@ -1,0 +1,44 @@
+{
+    "name": "DSpace",
+    "description": "DSpace is a turnkey institutional repository application.",
+    "icon": "https://janitor.technology/img/dspace.svg",
+    "docker": {
+      "image": "janitortechnology/dspace"
+    },
+    "ports": {
+      "22": {
+        "label": "SSH",
+        "proxy": "none"
+      },
+      "3000": {
+        "label": "Web",
+        "proxy": "https",
+        "preview": true
+      },
+      "8088": {
+        "label": "VNC",
+        "proxy": "https",
+        "preview": true
+      },
+      "8089": {
+        "label": "Cloud9",
+        "proxy": "https"
+      }
+    },
+    "scripts": {
+      "Run server": {
+        "cmd": "yarn run server",
+        "openPort": "3000"
+      },
+      "Install global dependencies": "yarn run global",
+      "Install local dependencies": "yarn install",
+      "Start": {
+        "cmd": "yarn start",
+        "openPort": "3000"
+      },
+      "Clean": "yarn run clean",
+      "Update source code": "git pull --rebase origin master",
+      "Send to code review": "hub pull-request"
+    }
+}
+


### PR DESCRIPTION
This PR adds the [Janitor](https://janitor.technology) [Dockerfile](https://github.com/JanitorTechnology/dockerfiles/tree/master/dspace) to this repository so that DSpace can be the owner of the Dockerfile.

cc @jankeromnes