### PR TITLE
Improve Docker Tutorial and Add Docker Compose Instructions

### DIFF
--- a/compose-dspace6-postgres/README.md
+++ b/compose-dspace6-postgres/README.md
@@ -1,0 +1,116 @@
+# Running DSpace with Docker compose
+
+## 1. Pre-requisites
+- [Setup](../tutorialSetup.md)
+- [Building DSpace](../tutorialBuild.md)
+- Make sure that the environment variable **DSPACE_SRC** is set to the directory containing your cloned DSpace repo
+
+## 2: Using Docker Compose
+
+- cd to the **compose-dspace6-postgres** directory
+
+Run Docker compose
+_In the following example, "d6" is being passed as a "compose project name".  This will be used to prefix the name of the network and volumes created by Docker.  This will permit you to maintain multiple variants of a DSpace install (ie DSpace 5 and DSpace 6)._
+
+    docker-compose -p d6 up -d
+
+### Deploy DSpace
+
+    docker exec -w /dspace-src/dspace/target/dspace-installer  d6_dspacetomcat_1 ant update clean_backups
+
+If necessary, you can start and stop tomcat with the following commands.
+
+    docker-compose -p d6 restart
+---
+## 3. Configuring DSpace Admin and Content
+
+#### Use the tomcat bash terminal to configure the DSpace administrator
+
+    docker exec -it --detach-keys "ctrl-p" d6_dspacetomcat_1 /bin/bash
+
+Bash Command
+```
+/dspace/bin/dspace create-administrator -e test@test.edu -f Admin -l User -p admin -c en
+```
+
+### Load AIP Files into DSpace
+
+Identify a set of AIP files to use for testing.
+
+A sample set is located [here](https://github.com/DSpace-Labs/DSpace-codenvy/tree/master/TestData).
+
+#### Copy the AIP files to the Docker Image
+
+In the **dspacetomcat bash terminal**, create an input directory
+
+    mkdir /tmp/testdata
+
+To facilitate the data import, use docker cp.
+
+    docker cp **yourLocalTestDataDir** d6_dspacetomcat_1:/tmp/testdata
+
+#### Load the AIP Files into DSpace
+
+In the bash window created above, run the following command to import data.
+```
+cd /tmp/testdata
+```
+
+```
+for file in COMM* COLL* ITEM*;
+do
+  /dspace/bin/dspace packager -r -t AIP -e test@test.edu -f -u $file
+done
+```
+
+#### Update the sequences in the DSpace database
+
+It is a long standing issue with AIP import files that necessitates reseting sequences after importing content from AIP Files.
+
+In the **dspacedb psql terminal**, run the following SQL to reset the database sequences.
+
+    docker exec -it --detach-keys "ctrl-p" d6_dspacedb_1 psql -U dspace
+
+SQL
+```
+SELECT
+  setval(
+    'handle_seq',
+    CAST (
+      max(
+      to_number(
+          regexp_replace(handle, '.*/', ''),
+          '999999999999'
+        )
+      )
+      AS BIGINT
+    )
+  )
+FROM handle
+WHERE handle SIMILAR TO '%/[0123456789]*';
+```
+
+## 4. Open DSpace in a Browser
+- DSpace 5 or 6: http://localhost:8080/xmlui
+- DSpace 7: http://localhost:8080/spring-rest
+
+## 5. Stopping DSpace
+
+    docker-compose -p d6 stop
+
+After stopping your instances, note that the volumes have persisted.
+
+    docker volume ls
+
+Sample Output
+```
+DRIVER              VOLUME NAME
+local               269bb301cec95f0bcb1c6f0b5e0947c33308d59628185856eb727a08f654980e
+local               d6_dspace
+local               d6_pgdata
+```
+
+## 6. Restarting DSpace
+_When DSpace is restarted, the contents of your volumes will be restored_
+
+    docker-compose -p d6 start

--- a/compose-dspace6-postgres/docker-compose.yml
+++ b/compose-dspace6-postgres/docker-compose.yml
@@ -3,11 +3,10 @@ version: "3.3"
 services:
   dspacedb:
     image: dspace/dspace-postgres-pgcrypto
-    container_name: dspacedb
     environment:
       - PGDATA=/pgdata
     volumes:
-       - pgdataD6:/pgdata
+       - pgdata:/pgdata
     networks:
       - dspacenet
     tty: true
@@ -15,14 +14,13 @@ services:
 
   dspacetomcat:
     image: dspace/dspace-tomcat
-    container_name: dspacetomcat
     environment:
       - DSPACE_INSTALL=/dspace
     ports:
       - 8080:8080
     volumes:
-       - dspaceD6:/dspace
-       - ${DSPACE_SRC}/dspace/target/dspace-installer:/dspace-src
+       - "dspace:/dspace"
+       - "${DSPACE_SRC}:/dspace-src"
     networks:
        - dspacenet
     depends_on:
@@ -31,8 +29,8 @@ services:
     stdin_open: true
 
 volumes:
-  pgdataD6:
-  dspaceD6:
+  pgdata:
+  dspace:
 
 networks:
   dspacenet:

--- a/compose-dspace6-postgres/docker-compose.yml
+++ b/compose-dspace6-postgres/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     container_name: dspacedb
     environment:
       - PGDATA=/pgdata
-    ports:
-      - 5432:5432
     volumes:
        - pgdataD6:/pgdata
     networks:
@@ -24,6 +22,7 @@ services:
       - 8080:8080
     volumes:
        - dspaceD6:/dspace
+       - ${DSPACE_SRC}/dspace/target/dspace-installer:/dspace-src
     networks:
        - dspacenet
     depends_on:

--- a/tutorial.md
+++ b/tutorial.md
@@ -100,8 +100,7 @@ If necessary, you can start and stop tomcat with the following commands.
 
     docker-compose restart
 ---
-## Configuring DSpace Admin and Content
----
+## 3. Configuring DSpace Admin and Content
 
 #### Use the tomcat bash terminal to configure the DSpace administrator
 
@@ -113,13 +112,13 @@ Bash Command
 ```
 
 ---
-## 3. Create User and Load AIP Files into DSpace
+### Load AIP Files into DSpace
 
 Identify a set of AIP files to use for testing.
 
 A sample set is located [here](https://github.com/DSpace-Labs/DSpace-codenvy/tree/master/TestData).
 
-### Copy the AIP files to the Docker Image
+#### Copy the AIP files to the Docker Image
 
 In the **dspacetomcat bash terminal**, create an input directory
 
@@ -129,7 +128,7 @@ To facilitate the data import, use docker cp.
 
     docker cp **yourSourceDir** dspacetomcat:/tmp/testdata
 
-### Load the AIP Files into DSpace
+#### Load the AIP Files into DSpace
 
 In the dspacetomcat bash window, run the following command to import data.
 ```
@@ -140,7 +139,7 @@ do
 done
 ```
 
-### Update the sequences in the DSpace database
+#### Update the sequences in the DSpace database
 
 It is a long standing issue with AIP import files that necessitates reseting sequences after importing content from AIP Files.
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -42,8 +42,8 @@ _This volume will persist you database data even if you stop the database server
 
 _Start the database service - this must be done before deployment_
 
-    docker run -it -d --network dspacenet -p 5432:5432 --name dspacedb -v pgdataD6:/pgdata -e PGDATA=/pgdata dspace/dspace-postgres-pgcrypto
-    
+    docker run -it -d --network dspacenet --name dspacedb -v pgdataD6:/pgdata -e PGDATA=/pgdata dspace/dspace-postgres-pgcrypto
+
 _Attach to the database server to query directly_
 
     docker exec -it --detach-keys "ctrl-p" dspacedb psql -U dspace
@@ -63,13 +63,70 @@ _This volume will persist the DSpace assetstore and solr content between runs_
 
     docker run -it --rm --network dspacenet -v "$(pwd)"/dspace/target/dspace-installer:/installer -v dspaceD6:/dspace -w /installer dspace/dspace-tomcat ant update clean_backups
 
-### Start tomcat 
+### Start tomcat
 
     docker run -it --network dspacenet -v dspaceD6:/dspace -p 8080:8080 --name dspacetomcat -e DSPACE_INSTALL=/dspace dspace/dspace-tomcat
 
-#### Attach to tomcat directly to run dspace commands (/dspace/bin/dspace)
+#### Attach to tomcat directly to run dspace commands in bash (/dspace/bin/dspace)
+_Note that ctrl-P is used to terminate the terminal session_
 
     docker exec -it --detach-keys "ctrl-p" dspacetomcat /bin/bash
+
+## Configuring DSpace Admin and Content
+
+#### Use the tomcat bash terminal to configure the DSpace administrator
+```
+/dspace/bin/dspace create-administrator -e test@test.edu -f Admin -l User -p admin -c en
+```
+
+## Load AIP Files into DSpace
+
+Identify a set of AIP files to use for testing.
+
+A sample set is located [here](https://github.com/DSpace-Labs/DSpace-codenvy/tree/master/TestData).
+
+### Copy the AIP files to the Docker Image
+
+In the **dspacetomcat bash terminal**, create an input directory
+
+    mkdir /tmp/testdata
+
+To facilitate the data import, use docker cp.
+
+    docker cp **yourSourceDir** dspacetomcat:/tmp/testdata
+
+### Load the AIP Files into DSpace
+
+In the dspacetomcat bash window, run the following command to import data.
+```
+cd /tmp/testdata
+for file in COMM* COLL* ITEM*;
+do
+  /dspace/bin/dspace packager -r -t AIP -e test@test.edu -f -u $file
+done
+```
+
+### Update the sequences in the DSpace database
+
+It is a long standing issue with AIP import files that necessitates reseting sequences after importing content from AIP Files.
+
+In the **dspacedb psql terminal**, run the following SQL to reset the database sequences.
+
+    SELECT
+      setval(
+        'handle_seq',
+        CAST (
+          max(
+            to_number(
+              regexp_replace(handle, '.*/', ''),
+              '999999999999'
+            )
+          )
+          AS BIGINT
+        )
+      )
+    FROM handle
+    WHERE handle SIMILAR TO '%/[0123456789]*';
 
 ## Open in a Browser
 - DSpace 6: http://localhost:8080/xmlui

--- a/tutorial.md
+++ b/tutorial.md
@@ -1,4 +1,4 @@
-## Pre-requisites
+## 1. Pre-requisites
 
 ### Before cloning the DSpace repo on Windows
 
@@ -21,9 +21,12 @@ _This file is already in the .gitignore file, it is intended to be localized_
 - Windows 10 Powershell: ${PWD}
 - MacOS: "$(pwd)"
 
+Note: There are 2 options for starting your Docker images.
+- Option 1: will build Docker images individually (good for learning)
+- Option 2: using Docker Compose (this is easier)
 ---
-## Option 1: Using the Docker Command
----
+## 2A: Option 1: Using the Docker Command
+
 
 ### Create network for our DSpace components
 
@@ -78,8 +81,7 @@ _Note that ctrl-P is used to terminate the terminal session_
     docker exec -it --detach-keys "ctrl-p" dspacetomcat /bin/bash
 
 ---
-## Option 2: Using Docker Compose
----
+## 2B: Option 2: Using Docker Compose
 
 Setup
 - Set **DSPACE_SRC** to the root directory for your DSpace code.
@@ -110,7 +112,8 @@ Bash Command
 /dspace/bin/dspace create-administrator -e test@test.edu -f Admin -l User -p admin -c en
 ```
 
-## Load AIP Files into DSpace
+---
+## 3. Create User and Load AIP Files into DSpace
 
 Identify a set of AIP files to use for testing.
 
@@ -163,7 +166,6 @@ SQL
     WHERE handle SIMILAR TO '%/[0123456789]*';
 
 ---
-## Open DSpace in a Browser
----
+## 4. Open DSpace in a Browser
 - DSpace 6: http://localhost:8080/xmlui
 - DSpace 7: http://localhost:8080/spring-rest

--- a/tutorial.md
+++ b/tutorial.md
@@ -1,49 +1,17 @@
-## 1. Pre-requisites
-
-### Before cloning the DSpace repo on Windows
-
-    git config --global core.autocrlf false
-    git config --global core.eol lf
-
-### DSpace Branch:
-- dspace-6_x
-- master
-
-### Create local.cfg for the Docker image in the DSpace root directory
-_This file is already in the .gitignore file, it is intended to be localized_
-
-- dspace.dir=/dspace
-- db.url = jdbc:postgresql://dspacedb:5432/dspace
-- dspace.hostname = dspacetomcat
-- dspace.baseUrl = http://dspacetomcat:8080
-
-### Note on passing working directory to Docker
-- Windows 10 Powershell: ${PWD}
-- MacOS: "$(pwd)"
-
-Note: There are 2 options for starting your Docker images.
-- Option 1: will build Docker images individually (good for learning)
-- Option 2: using Docker Compose (this is easier)
----
-## 2A: Option 1: Using the Docker Command
+# Deploying DSpace to Docker Manually
+_This tutorial describes the individual steps for deploying DSpace to Docker using the docker command.  See [compose-dspace6-postgres](compose-dspace6-postgres) for an automated setup using Docker compose.  This tutorial is useful for understanding how Docker manages DSpace components._
 
 
-### Create network for our DSpace components
+## Pre-requisites
+- [Setup](tutorialSetup.md)
+- [Building DSpace](tutorialBuild.md)
+- Make sure that the environment variable **DSPACE_SRC** is set to the directory containing your cloned DSpace repo
+
+## Create network for our DSpace components
 
     docker network create dspacenet
 
-### Build DSpace
-_It is not necessary to run this step using Docker. The following instructions illustrate how Docker can be used to run Docker._
-
-#### Windows Flavor
-
-    docker run -it --rm -v ${HOME}/.m2:/root/.m2 -v ${PWD}:/opt/maven -w /opt/maven maven mvn clean install
-
-#### MacOS Flavor
-
-    docker run -it --rm -v "$(home)":/root/.m2 -v "$(pwd)":/opt/maven -w /opt/maven maven mvn clean install
-
-### Create DSpace Database
+## Create DSpace Database
 _This volume will persist you database data even if you stop the database server_
 
     docker volume create pgdataD6
@@ -56,16 +24,16 @@ _Attach to the database server to query directly_
 
     docker exec -it --detach-keys "ctrl-p" dspacedb psql -U dspace
 
-### Create DSpace Deployment
+## Create DSpace Deployment
 _This volume will persist the DSpace assetstore and solr content between runs_
 
     docker volume create dspaceD6
 
-#### Deploy/install DSpace_
+## Deploy/install DSpace_
 
 Windows Flavor
 
-    docker run -it --rm --network dspacenet -v ${PWD}/dspace/target/dspace-installer:/installer -v dspaceD6:/dspace -w /installer dspace/dspace-tomcat ant update clean_backups
+    docker run -it --rm --network dspacenet -v ${DSPACE_SRC}/dspace/target/dspace-installer:/installer -v dspaceD6:/dspace -w /installer dspace/dspace-tomcat ant update clean_backups
 
 MacOS Flavor
 
@@ -80,43 +48,17 @@ _Note that ctrl-P is used to terminate the terminal session_
 
     docker exec -it --detach-keys "ctrl-p" dspacetomcat /bin/bash
 
----
-## 2B: Option 2: Using Docker Compose
-
-Setup
-- Set **DSPACE_SRC** to the root directory for your DSpace code.
-- Run the maven build
-- cd to the **compose-dspace6-postgres** directory
-
-Run Docker compose
-_In the following example, "d6" is being passed as a "compose project name".  This will be used to prefix the name of the network and volumes created by Docker.  This will permit you to maintain multiple variants of a DSpace install (ie DSpace 5 and DSpace 6)._
-
-    docker-compose -p d6 up -d
-
-### Deploy DSpace
-
-    docker exec -w /dspace-src/dspace/target/dspace-installer  d6_dspacetomcat_1 ant update clean_backups
-
-If necessary, you can start and stop tomcat with the following commands.
-
-    docker-compose -p d6 restart
----
 ## 3. Configuring DSpace Admin and Content
-_If you started the images with docker-compose, replace the image **dspacetomcat** with the qualified image name such as **D6_dspacetomcat_1**_
 
-
-#### Use the tomcat bash terminal to configure the DSpace administrator
+### Use the tomcat bash terminal to configure the DSpace administrator
 
     docker exec -it --detach-keys "ctrl-p" dspacetomcat /bin/bash
-
-    docker exec -it --detach-keys "ctrl-p" d6_dspacetomcat_1 /bin/bash
 
 Bash Command
 ```
 /dspace/bin/dspace create-administrator -e test@test.edu -f Admin -l User -p admin -c en
 ```
 
----
 ### Load AIP Files into DSpace
 
 Identify a set of AIP files to use for testing.
@@ -131,9 +73,7 @@ In the **dspacetomcat bash terminal**, create an input directory
 
 To facilitate the data import, use docker cp.
 
-    docker cp **yourSourceDir** dspacetomcat:/tmp/testdata
-
-    docker cp **yourSourceDir** d6_dspacetomcat_1:/tmp/testdata
+    docker cp **yourLocalTestDataDir** dspacetomcat:/tmp/testdata
 
 #### Load the AIP Files into DSpace
 
@@ -149,15 +89,13 @@ do
 done
 ```
 
-#### Update the sequences in the DSpace database
+### Update the sequences in the DSpace database
 
 It is a long standing issue with AIP import files that necessitates reseting sequences after importing content from AIP Files.
 
 In the **dspacedb psql terminal**, run the following SQL to reset the database sequences.
 
     docker exec -it --detach-keys "ctrl-p" dspacedb psql -U dspace
-
-    docker exec -it --detach-keys "ctrl-p" d6_dspacedb_1 psql -U dspace
 
 SQL
 ```
@@ -178,42 +116,17 @@ FROM handle
 WHERE handle SIMILAR TO '%/[0123456789]*';
 ```
 
----
 ## 4. Open DSpace in a Browser
 - DSpace 6: http://localhost:8080/xmlui
 - DSpace 7: http://localhost:8080/spring-rest
 
 ## 5. Stopping DSpace
 
-If you started the instances with the docker command...
-
     docker stop dspacetomcat
     docker stop dspacedb
-
-If you started the instances with docker-Compose
-
-    docker-compose -p d6 stop
-
-After stopping your instances, note that the volumes have persisted.
-
-    docker volume ls
-
-Sample Output
-```
-DRIVER              VOLUME NAME
-local               269bb301cec95f0bcb1c6f0b5e0947c33308d59628185856eb727a08f654980e
-local               d6_dspace
-local               d6_pgdata
-```
 
 ## 6. Restarting DSpace
 _When DSpace is restarted, the contents of your volumes will be restored_
 
-If you started the instances with the docker command...
-
     docker start dspacetomcat
     docker start dspacedb
-
-If you started the instances with docker-Compose
-
-    docker-compose -p d6 start

--- a/tutorialBuild.md
+++ b/tutorialBuild.md
@@ -1,0 +1,16 @@
+# Build DSpace for Docker
+_It is not necessary to run this step using Docker. The following instructions illustrate how Docker can be used to run Docker._
+
+_If you have maven installed locally, it is probably preferable to run the maven build using your local mave installation._
+
+## Building DSpace Using Docker
+
+Set the environment variable **DSPACE_SRC** to the root directory of your cloned DSpace repository.
+
+- MacOS or bash: `export DSPACE_SRC=$(pwd)`
+- Windows CMD: `set DSPACE_SRC=%cd%`
+- Windows Powershell: ???
+
+### Run Maven in Docker
+
+    docker run -it --rm -v ${HOME}/.m2:/root/.m2 -v ${DSPACE_SRC}:/opt/maven -w /opt/maven maven mvn clean install

--- a/tutorialSetup.md
+++ b/tutorialSetup.md
@@ -1,0 +1,30 @@
+# Setting Up DSpace on Docker
+
+## Install Docker
+- [Docker Install](https://docs.docker.com/install/)
+
+## If you are running Docker for Windows
+_You must manage your line endings for files that will be deployed to Docker_
+
+TODO: should this config setting be localized to just the DSpace Repo?
+
+    git config --global core.autocrlf false
+    git config --global core.eol lf
+
+## Checkout DSpace Using Git
+- dspace-6_x
+- master
+
+## Create local.cfg for the Docker image in the DSpace root directory
+_This file is already in the .gitignore file, it is intended to be localized_
+
+- dspace.dir=/dspace
+- db.url = jdbc:postgresql://dspacedb:5432/dspace
+- dspace.hostname = dspacetomcat
+- dspace.baseUrl = http://dspacetomcat:8080
+
+If you are building DSpace 5, these changes must be made in the build.properties file
+
+### Note on passing working directory to Docker
+- Windows 10 Powershell: ${PWD}
+- MacOS: "$(pwd)"


### PR DESCRIPTION
### Question for reviewers
- Would you prefer to review this as a PR, or review it after changes are merged?
- Should the tutorial be one page or multiple pages?
- Should there be a separate page for the raw docker commands vs docker compose?
- Should we provide instructions for both mechanisms or simply document the docker compose approach?
- How easily could we extend this tutorial to build the full stack for DSpace 7 (database, rest, angular)?
- I think the "docker cp" approach is OK for loading AIP files since that should only need to be done once.

Also, see the [issues](https://github.com/DSpace-Labs/DSpace-Docker-Images/issues) recorded for this repo.