### PR TITLE
Simplify image build dependency

### DIFF
--- a/dockerfiles/dspace/Dockerfile
+++ b/dockerfiles/dspace/Dockerfile
@@ -25,4 +25,3 @@ RUN ant update_configs update_code update_webapps update_solr_indexes
 
 FROM dspace/dspace-tomcat
 COPY --from=ant_build /dspace /dspace
-RUN /dspace/bin/dspace version

--- a/dockerfiles/dspace/Dockerfile
+++ b/dockerfiles/dspace/Dockerfile
@@ -21,7 +21,7 @@ FROM dspace/dspace-tomcat as ant_build
 ARG TARGET_DIR=dspace-installer
 COPY --from=build /app /dspace-src
 WORKDIR /dspace-src/dspace/target/${TARGET_DIR}
-RUN ant update clean_backups
+RUN ant update_configs update_code update_webapps update_solr_indexes
 
 FROM dspace/dspace-tomcat
 COPY --from=ant_build /dspace /dspace

--- a/dockerfiles/dspace/README.md
+++ b/dockerfiles/dspace/README.md
@@ -1,16 +1,10 @@
 
 ## Configure the Build Environment
-In order to build this, you must start the database
-
-```
-docker network create dspace-build
-docker run -it -d --network dspace-build --name dspacedb dspace/dspace-postgres-pgcrypto
-```
 
 Build dspace docker (note dspace-6_x will build by default)
 
 ```
-docker build .  --network dspace-build -t dspace/dspace:dspace-6_x --no-cache
+docker build . -t dspace/dspace:dspace-6_x --no-cache
 ```
 
 ### Building a specific release
@@ -18,71 +12,22 @@ To build a specific branch or tag, you can pass in the branch/tag name
 
 #### DSpace master
 ```
-docker build .  --build-arg DSPACE_BRANCH=master --network dspace-build -t dspace/dspace:master --no-cache
-```
-
-You can verify the version after your build by Running
-```
-docker run --rm --network dspace-build dspace/dspace:master /dspace/bin/dspace version
+docker build .  --build-arg DSPACE_BRANCH=master -t dspace/dspace:master --no-cache
 ```
 
 #### DSpace 6.3
 ```
-docker build .  --build-arg DSPACE_BRANCH=dspace-6.3 --network dspace-build -t dspace/dspace:dspace-6.3 --no-cache
-```
-
-You can verify the version after your build by Running
-
-##### Bash
-```
-docker run --rm --network dspace-build dspace/dspace:dspace-6.3 /dspace/bin/dspace version
-```
-
-##### Git-Bash Windows
-```
-docker run --rm --network dspace-build dspace/dspace:dspace-6.3 //dspace/bin/dspace version
+docker build .  --build-arg DSPACE_BRANCH=dspace-6.3 -t dspace/dspace:dspace-6.3 --no-cache
 ```
 
 #### DSpace 5.9
 ```
-docker build .  --build-arg DSPACE_BRANCH=dspace-5.9 --network dspace-build -t dspace/dspace:dspace-5.9 --no-cache
-```
-
-You can verify the version after your build by Running
-
-##### Bash
-```
-docker run --rm --network dspace-build dspace/dspace:dspace-5.9 /dspace/bin/dspace version
-```
-
-##### Git-Bash Windows
-```
-docker run --rm --network dspace-build dspace/dspace:dspace-5.9 //dspace/bin/dspace version
+docker build .  --build-arg DSPACE_BRANCH=dspace-5.9 -t dspace/dspace:dspace-5.9 --no-cache
 ```
 
 #### DSpace 4.9
 ```
-docker build .  --build-arg DSPACE_BRANCH=dspace-4.9 --build-arg TARGET_DIR=dspace-build --network dspace-build -t dspace/dspace:dspace-4.9 --no-cache
-```
-
-You can verify the version after your build by Running
-##### Bash
-```
-docker run --rm --network dspace-build dspace/dspace:dspace-4.9 /dspace/bin/dspace version
-```
-
-##### Git-Bash Windows
-```
-docker run --rm --network dspace-build dspace/dspace:dspace-4.9 /dspace/bin/dspace version
-```
-
-## Destroy the Build Environment
-In order to ensure that your next build starts from a clean environment, remove the components that were created.
-
-```
-docker network rm dspace-build
-docker stop dspacedb
-docker rm dspacedb
+docker build .  --build-arg DSPACE_BRANCH=dspace-4.9 --build-arg TARGET_DIR=dspace-build -t dspace/dspace:dspace-4.9 --no-cache
 ```
 
 ## Full Build Script (for pushing to Dockerhub)
@@ -96,17 +41,9 @@ export DTAG=master
 export DDIR=dspace-installer
 # export DDIR=dspace-build
 
-docker network rm dspace-build
-docker stop dspacedb
-docker rm dspacedb
 docker image prune -f
 
-docker network create dspace-build
-docker run -it -d --network dspace-build --name dspacedb dspace/dspace-postgres-pgcrypto
-
-docker build .  --build-arg DSPACE_BRANCH=$DTAG --build-arg TARGET_DIR=$DDIR --network dspace-build -t dspace/dspace:$DTAG --no-cache
+docker build .  --build-arg DSPACE_BRANCH=$DTAG --build-arg TARGET_DIR=$DDIR -t dspace/dspace:$DTAG --no-cache
 
 docker push dspace/dspace:$DTAG
-docker run --rm --network dspace-build dspace/dspace:$DTAG //dspace/bin/dspace version
-
 ```


### PR DESCRIPTION
Eliminate the ant test_database task from the ant deploy task.  This removes the dependency on a database image when running the build.