### PR TITLE
Adjust verify script to use compose file fragments

### DIFF
--- a/docker-compose-files/dspace-compose/verify.yml
+++ b/docker-compose-files/dspace-compose/verify.yml
@@ -1,5 +1,9 @@
 version: "3.7"
 
+# This docker compose file will start up a minimal instance of DSpace.
+# This file is used by /tools/verify.yml to ensure that each published image is
+# configured as expected.
+
 services:
   dspace:
     entrypoint: catalina.sh run

--- a/docker-compose-files/dspace-compose/verify.yml
+++ b/docker-compose-files/dspace-compose/verify.yml
@@ -1,0 +1,5 @@
+version: "3.7"
+
+services:
+  dspace:
+    entrypoint: catalina.sh run

--- a/tools/verifyImages.sh
+++ b/tools/verifyImages.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # CD to docker-compose dir
-export DOCKER_OWNER=terrywbrady
+export DOCKER_OWNER=${DOCKER_OWNER:-dspace}
 export DPROJ=test-image
 
 function checkOutput {
@@ -24,7 +24,7 @@ function checkImage {
   export STAT_SOLR=$6
   export STAT_REST=$7
   docker-compose -p $DPROJ -f docker-compose.yml -f verify.yml up -d > /dev/null 2> /dev/null
-  echo " ===== ${DSPACE_VER} ===== "
+  echo " ===== ${DOCKER_OWNER}/dspace:${DSPACE_VER} ===== "
   docker exec dspace //dspace/bin/dspace version | egrep "DSpace version:|JRE:" > /tmp/out.txt
   cat /tmp/out.txt
   checkOutput ${DSPACE_REGEX} "Unexpected DSpace Version - Expected ${DSPACE_REGEX}"
@@ -58,6 +58,9 @@ function removeVols {
     docker volume rm $vol
   done
 }
+
+checkImage dspace-4_x-jdk7-test 4.10-SNAPSHOT "version 1.7" 500 200 200 200
+exit
 
 #
 # Default Images - SOLR and REST* are inaccessible

--- a/tools/verifyImages.sh
+++ b/tools/verifyImages.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # CD to docker-compose dir
-export DOCKER_OWNER=dspace
+export DOCKER_OWNER=terrywbrady
 export DPROJ=test-image
 
 function checkOutput {
@@ -23,7 +23,7 @@ function checkImage {
   export STAT_OAI=$5
   export STAT_SOLR=$6
   export STAT_REST=$7
-  docker-compose -p $DPROJ up -d > /dev/null 2> /dev/null
+  docker-compose -p $DPROJ -f docker-compose.yml -f verify.yml up -d > /dev/null 2> /dev/null
   echo " ===== ${DSPACE_VER} ===== "
   docker exec dspace //dspace/bin/dspace version | egrep "DSpace version:|JRE:" > /tmp/out.txt
   cat /tmp/out.txt


### PR DESCRIPTION
Also, show the full image name for the image being tested.