### PR TITLE
Add external solr for DSpace 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,6 @@ This repository contains the source code for Docker Images for the [DSpace](http
 
 ---
 
-## How is this Code Repository Organized?
-![DSpace Docker Overview Diagram](documentation/DSpaceDockerFlow.png)
-
 ## Published Images
 This table lists the general purpose docker images supported by the DSpace project.  These images are intended to support the testing and development of DSpace from a user's desktop.
 
@@ -44,12 +41,20 @@ This table lists the general purpose docker images supported by the DSpace proje
 | [dspace](https://github.com/DSpace/DSpace/blob/master/Dockerfile) | Published |[dspace/dspace](https://hub.docker.com/r/dspace/dspace/)| dspace-7_x-jdk8<br/><br/>dspace-6_x-jdk8<br/><br/>dspace-5_x-jdk7<br/><br/>[tag notes](https://wiki.duraspace.org/display/DSPACE/DSpace+and+Docker) | Tomcat + Ant with populated dspace-install directory. <br/>DSpace code will be cloned and built during image build. <br/>Image contains local.cfg or build.properties file suitable for the container.<br/>Image variants for "test" exist to make it easier to access all web services.|
 | [dspace-angular](https://github.com/DSpace/dspace-angular/blob/docker/Dockerfile) | Published |[dspace/dspace-angular](https://hub.docker.com/r/dspace/dspace-angular/)| latest| Containerized Angular UI |
 | [dspace-angular-bare](https://github.com/DSpace-Labs/DSpace-Docker-Images/tree/master/dockerfiles/dspace-angular-bare/) | Provisionally Published  |[dspace/dspace-angular-bare](https://hub.docker.com/r/dspace/dspace-angular-bare/)| latest|  Containerized Angular UI which allows you to mount a source directory_|
+| [dspace-solr](https://github.com/DSpace/DSpace/blob/master/src/main/docker/solr/Dockerfile)* | Published | [dspace/dspace-solr](https://hub.docker.com/r/dspace/dspace-solr) | latest | External Solr Instance containing the 4 DSpace Solr repositories. *Depends on PR 2058 |
 
 ## Compose files
 The following Docker Compose files can be used to simplify the management of DSpace components allowing a user to run an end-to-end DSpace instance from their desktop.
 
 ### Main DSpace Compose Files
 [DSpace Compose Files](docker-compose-files/dspace-compose/ComposeFiles.md)
+- Base DSpace Compose File: docker-compose.yml
+- DSpace 7 Compose File: d7.override.yml (d7solr.override.yml - until PR 2058 is merged)
+- DSpace 6 Compose File: d6.override.yml
+- DSpace 5 Compose File: d5.override.yml
+- DSpace 4 Compose File: d4.override.yml
+- DSpace RDF Compose File: rdf.override.yml
+- DSpace Local Build Compose File: src.override.yml
 
 ### Special Purpose Compose files
 

--- a/docker-compose-files/dspace-compose/README.md
+++ b/docker-compose-files/dspace-compose/README.md
@@ -31,14 +31,17 @@ CONTAINER ID        IMAGE                             COMMAND                  C
 5186cf451eff        dspace/dspace-postgres-pgcrypto   "docker-entrypoint.s…"   About a minute ago   Up About a minute   5432/tcp                           dspacedb
 ```
 
-The dspace container and the dspacedb container will persist data in a docker volume.
+The dspace container and the dspacedb container will persist data in a docker volume.  Each Solr repository will be saved to a docker volume.
 
 ```
 $ docker volume ls -f "label=com.docker.compose.project=d6"
 DRIVER              VOLUME NAME
 local               d6_assetstore
 local               d6_pgdata
-local               d6_solr
+local               d6_solr_authority
+local               d6_solr_oai
+local               d6_solr_search
+local               d6_solr_statistics
 ```
 
 ### 2a. Passing Variables and Properties to DSpace
@@ -131,7 +134,10 @@ $ docker volume ls -f "label=com.docker.compose.project=d6"
 DRIVER              VOLUME NAME
 local               d6_assetstore
 local               d6_pgdata
-local               d6_solr
+local               d6_solr_authority
+local               d6_solr_oai
+local               d6_solr_search
+local               d6_solr_statistics
 ```
 
 ## 7. Restarting DSpace
@@ -155,7 +161,7 @@ docker-compose -p d6 down
 If you no longer need to retain your Docker volumes, run  the following commands.
 
 ```
-docker volume rm d6_assetstore d6_pgdata d6_solr
+docker volume rm d6_assetstore d6_pgdata d6_solr_authority d6_solr_oai d6_solr_search d6_solr_statistics
 ```
 A helper script exists in this repository to remove volumes.
 

--- a/docker-compose-files/dspace-compose/d4.override.yml
+++ b/docker-compose-files/dspace-compose/d4.override.yml
@@ -7,3 +7,5 @@ services:
   dspace:
     image: "${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-dspace-4_x-jdk7-test}"
     entrypoint: /dspace-docker-tools/ingestAIPd4.sh
+    volumes:
+      - "solr:/dspace/solr"

--- a/docker-compose-files/dspace-compose/d4.override.yml
+++ b/docker-compose-files/dspace-compose/d4.override.yml
@@ -8,4 +8,7 @@ services:
     image: "${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-dspace-4_x-jdk7-test}"
     entrypoint: /dspace-docker-tools/ingestAIPd4.sh
     volumes:
-      - "solr:/dspace/solr"
+      - "solr_authority:/dspace/solr/authority/data"
+      - "solr_oai:/dspace/solr/oai/data"
+      - "solr_search:/dspace/solr/search/data"
+      - "solr_statistics:/dspace/solr/statistics/data"

--- a/docker-compose-files/dspace-compose/d5.override.yml
+++ b/docker-compose-files/dspace-compose/d5.override.yml
@@ -5,3 +5,4 @@ services:
     image: "${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-dspace-5_x-jdk8-test}"
     volumes:
      - "../../add-ons/mirage2/xmlui.xconf:/dspace/config/xmlui.xconf"
+     - "solr:/dspace/solr"

--- a/docker-compose-files/dspace-compose/d5.override.yml
+++ b/docker-compose-files/dspace-compose/d5.override.yml
@@ -4,7 +4,7 @@ services:
   dspace:
     image: "${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-dspace-5_x-jdk8-test}"
     volumes:
-     - "../../add-ons/mirage2/xmlui.xconf:/dspace/config/xmlui.xconf"
+      - "../../add-ons/mirage2/xmlui.xconf:/dspace/config/xmlui.xconf"
       - "solr_authority:/dspace/solr/authority/data"
       - "solr_oai:/dspace/solr/oai/data"
       - "solr_search:/dspace/solr/search/data"

--- a/docker-compose-files/dspace-compose/d5.override.yml
+++ b/docker-compose-files/dspace-compose/d5.override.yml
@@ -5,4 +5,7 @@ services:
     image: "${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-dspace-5_x-jdk8-test}"
     volumes:
      - "../../add-ons/mirage2/xmlui.xconf:/dspace/config/xmlui.xconf"
-     - "solr:/dspace/solr"
+      - "solr_authority:/dspace/solr/authority/data"
+      - "solr_oai:/dspace/solr/oai/data"
+      - "solr_search:/dspace/solr/search/data"
+      - "solr_statistics:/dspace/solr/statistics/data"

--- a/docker-compose-files/dspace-compose/d6.override.yml
+++ b/docker-compose-files/dspace-compose/d6.override.yml
@@ -5,4 +5,7 @@ services:
     image: "${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-dspace-6_x-jdk8-test}"
     volumes:
       - "../../add-ons/mirage2/xmlui.xconf:/dspace/config/xmlui.xconf"
-      - "solr:/dspace/solr"
+      - "solr_authority:/dspace/solr/authority/data"
+      - "solr_oai:/dspace/solr/oai/data"
+      - "solr_search:/dspace/solr/search/data"
+      - "solr_statistics:/dspace/solr/statistics/data"

--- a/docker-compose-files/dspace-compose/d6.override.yml
+++ b/docker-compose-files/dspace-compose/d6.override.yml
@@ -5,3 +5,4 @@ services:
     image: "${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-dspace-6_x-jdk8-test}"
     volumes:
       - "../../add-ons/mirage2/xmlui.xconf:/dspace/config/xmlui.xconf"
+      - "solr:/dspace/solr"

--- a/docker-compose-files/dspace-compose/d7.override.yml
+++ b/docker-compose-files/dspace-compose/d7.override.yml
@@ -3,6 +3,8 @@ version: "3.7"
 services:
   dspace:
     image: "${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-dspace-7_x-jdk8-test}"
+    environment:
+      - "JAVA_OPTS=-Dsolr.server=http://dspacesolr:8983/solr"
 
   dspace-angular:
     image: dspace/dspace-angular
@@ -25,5 +27,17 @@ services:
       - dspacenet
     depends_on:
       - dspace
+    tty: true
+    stdin_open: true
+
+  dspacesolr:
+    image: dspace/dspace-solr
+    container_name: dspacesolr
+    ports:
+     - "8983:8983"
+    networks:
+      - dspacenet
+    volumes:
+      - "solr:/opt/solr/server/solr"
     tty: true
     stdin_open: true

--- a/docker-compose-files/dspace-compose/d7solr.override.yml
+++ b/docker-compose-files/dspace-compose/d7solr.override.yml
@@ -1,14 +1,14 @@
 version: "3.7"
 
+# This file adds an externalized Solr service.
+# Once the following PR is merged, this file will replace d7.override.yml
+# https://github.com/DSpace/DSpace/pull/2058/files
+
 services:
   dspace:
     image: "${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-dspace-7_x-jdk8-test}"
-    volumes:
-      # Eventually, these volumes will be moved to an external solr container
-      - "solr_authority:/dspace/solr/authority/data"
-      - "solr_oai:/dspace/solr/oai/data"
-      - "solr_search:/dspace/solr/search/data"
-      - "solr_statistics:/dspace/solr/statistics/data"
+    environment:
+      - "JAVA_OPTS=-Dsolr.server=http://dspacesolr:8983/solr"
 
   dspace-angular:
     image: dspace/dspace-angular
@@ -31,5 +31,20 @@ services:
       - dspacenet
     depends_on:
       - dspace
+    tty: true
+    stdin_open: true
+
+  dspacesolr:
+    image: dspace/dspace-solr
+    container_name: dspacesolr
+    ports:
+     - "8983:8983"
+    networks:
+      - dspacenet
+    volumes:
+      - "solr_authority:/opt/solr/server/solr/authority/data"
+      - "solr_oai:/opt/solr/server/solr/oai/data"
+      - "solr_search:/opt/solr/server/solr/search/data"
+      - "solr_statistics:/opt/solr/server/solr/statistics/data"
     tty: true
     stdin_open: true

--- a/docker-compose-files/dspace-compose/d7solr.override.yml
+++ b/docker-compose-files/dspace-compose/d7solr.override.yml
@@ -7,8 +7,6 @@ version: "3.7"
 services:
   dspace:
     image: "${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-dspace-7_x-jdk8-test}"
-    environment:
-      - "JAVA_OPTS=-Dsolr.server=http://dspacesolr:8983/solr"
 
   dspace-angular:
     image: dspace/dspace-angular

--- a/docker-compose-files/dspace-compose/docker-compose.yml
+++ b/docker-compose-files/dspace-compose/docker-compose.yml
@@ -42,7 +42,11 @@ services:
 volumes:
   pgdata:
   assetstore:
-  solr:
+  # The Solr volumes will be defined in one of the dX.override.yml files
+  solr_authority:
+  solr_oai:
+  solr_search:
+  solr_statistics:
 
 networks:
   dspacenet:

--- a/docker-compose-files/dspace-compose/docker-compose.yml
+++ b/docker-compose-files/dspace-compose/docker-compose.yml
@@ -30,7 +30,6 @@ services:
       - 8080:8080
     volumes:
       - "assetstore:/dspace/assetstore"
-      - "solr:/dspace/solr"
       - "../../add-ons/dspace-docker-tools:/dspace-docker-tools"
     entrypoint: /dspace-docker-tools/ingestAIP.sh
     networks:

--- a/tools/verifyImages.sh
+++ b/tools/verifyImages.sh
@@ -59,9 +59,6 @@ function removeVols {
   done
 }
 
-checkImage dspace-4_x-jdk7-test 4.10-SNAPSHOT "version 1.7" 500 200 200 200
-exit
-
 #
 # Default Images - SOLR and REST* are inaccessible
 # ------------------------------------------------


### PR DESCRIPTION
This PR is intended to support the Externalized Solr 7 upgrade.  See https://github.com/DSpace/DSpace/pull/2058

This change depends on https://cloud.docker.com/u/dspace/repository/docker/dspace/dspace-solr

This PR also established a separate docker volume for each Solr repo which is described here: https://github.com/DSpace-Labs/DSpace-Docker-Images/issues/80