### PR TITLE
Environment db__url --> db.url; Add to environment.cfg file

### DIFF
--- a/add-ons/dspace-docker-tools/ingestAIP.sh
+++ b/add-ons/dspace-docker-tools/ingestAIP.sh
@@ -2,7 +2,7 @@
 # Once this file has been saved to a docker volume, the ingest step will not be re-run
 CHECKFILE=/dspace/assetstore/ingest.hasrun.flag
 
-env | egrep "__.*=" | egrep -v "=.*__" | sed -e s/__/./g > /dspace/config/enfironment.cfg
+env | egrep "__.*=" | egrep -v "=.*__" | sed -e s/__/./g > /dspace/config/environment.cfg
 
 export JAVA_OPTS="${JAVA_OPTS} -Xmx2500m -Dupload.temp.dir=/dspace/upload -Djava.io.tmpdir=/tmp"
 

--- a/add-ons/dspace-docker-tools/ingestAIP.sh
+++ b/add-ons/dspace-docker-tools/ingestAIP.sh
@@ -2,6 +2,8 @@
 # Once this file has been saved to a docker volume, the ingest step will not be re-run
 CHECKFILE=/dspace/assetstore/ingest.hasrun.flag
 
+env | egrep "__.*=" | egrep -v "=.*__" | sed -e s/__/./g > /dspace/config/enfironment.cfg
+
 export JAVA_OPTS="${JAVA_OPTS} -Xmx2500m -Dupload.temp.dir=/dspace/upload -Djava.io.tmpdir=/tmp"
 
 if [ ! -f $CHECKFILE ]

--- a/docker-compose-files/dspace-compose/config-definition.xml
+++ b/docker-compose-files/dspace-compose/config-definition.xml
@@ -22,16 +22,24 @@
         <!-- Load Environment variables (does not automatically reload) -->
         <env/>
 
+        <!-- Allows docker insertion of properties containing periods from environment variables -->
+        <properties fileName="environment.cfg" throwExceptionOnMissing="false" config-optional="true"
+                    encoding="UTF-8"/>
         <!-- Allow user to override any configs in a local.cfg -->
         <!-- Any properties in this config will override defaults in dspace.cfg (or any included *.cfg file) -->
         <!-- Check for reload every 5 seconds (5,000ms) -->
-        <properties fileName="local.cfg" throwExceptionOnMissing="false" config-name="local" config-optional="true"
-                    encoding="UTF-8" config-reload="true" reloadingRefreshDelay="5000"/>
+        <properties fileName="local.cfg" throwExceptionOnMissing="false" config-name="local" config-optional="true" encoding="UTF-8">
+            <!-- Reload this file if it has changed, and at least 5 seconds (5,000 ms) have passed -->
+            <reloadingStrategy refreshDelay="5000"
+                config-class="org.apache.commons.configuration.reloading.FileChangedReloadingStrategy"/>
+        </properties>
 
         <!-- Load our dspace.cfg (which in turn loads all module configs via "include=" statements) -->
-        <!-- Check for reload every 5 seconds (5,000ms) -->
-        <properties fileName="dspace.cfg" throwExceptionOnMissing="true" encoding="UTF-8" config-reload="true"
-                    reloadingRefreshDelay="5000"/>
+        <properties fileName="dspace.cfg" throwExceptionOnMissing="true" encoding="UTF-8">
+            <!-- Reload this file if it has changed, and at least 5 seconds (5,000 ms) have passed -->
+            <reloadingStrategy refreshDelay="5000"
+                config-class="org.apache.commons.configuration.reloading.FileChangedReloadingStrategy"/>
+        </properties>
     </override>
 
 </configuration>

--- a/docker-compose-files/dspace-compose/config-definition.xml
+++ b/docker-compose-files/dspace-compose/config-definition.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!--
+     DSpace Configuration Definition
+     This Apache Commons Configuration definition file defines the ordering of configuration files loaded by DSpace.
+     Optionally, you may choose to add additional configuration files/locations.
+
+     For more information and examples of valid configuration definition files, see:
+     https://commons.apache.org/proper/commons-configuration/userguide/howto_combinedbuilder.html
+-->
+<configuration>
+    <!-- Configurations in this section override one another.
+         Earlier values take precedence, and override any values in later config files -->
+    <override>
+        <!-- By default, we load all System Properties and Environment variables, in case any override default settings
+             (e.g. "-Ddspace.dir" will override "dspace.dir"). Optionally, you could choose to disable this setting, but
+             still load individual settings from System or Env using variable interpolation,
+             e.g. ${sys:dspace.dir} or ${env:DSPACE_HOME}
+             For more info see:
+             https://commons.apache.org/proper/commons-configuration/userguide/howto_basicfeatures.html#Variable_Interpolation -->
+        <!-- Load Java System properties (does not automatically reload) -->
+        <system/>
+        <!-- Load Environment variables (does not automatically reload) -->
+        <env/>
+
+        <!-- Allow user to override any configs in a local.cfg -->
+        <!-- Any properties in this config will override defaults in dspace.cfg (or any included *.cfg file) -->
+        <!-- Check for reload every 5 seconds (5,000ms) -->
+        <properties fileName="local.cfg" throwExceptionOnMissing="false" config-name="local" config-optional="true"
+                    encoding="UTF-8" config-reload="true" reloadingRefreshDelay="5000"/>
+
+        <!-- Load our dspace.cfg (which in turn loads all module configs via "include=" statements) -->
+        <!-- Check for reload every 5 seconds (5,000ms) -->
+        <properties fileName="dspace.cfg" throwExceptionOnMissing="true" encoding="UTF-8" config-reload="true"
+                    reloadingRefreshDelay="5000"/>
+    </override>
+
+</configuration>

--- a/docker-compose-files/dspace-compose/docker-compose.yml
+++ b/docker-compose-files/dspace-compose/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       # Number of sec to wait before attempting to start tomcat
       - DBWAIT=0
       # Double underbars in env names will be replaced with periods for apache commons
-      dspace__name=DSpace Started with Docker Compose
+      - dspace__name=DSpace Started with Docker Compose
     ports:
       - ${PORT:-8080}:8080
     volumes:

--- a/docker-compose-files/dspace-compose/docker-compose.yml
+++ b/docker-compose-files/dspace-compose/docker-compose.yml
@@ -32,15 +32,14 @@ services:
       - AIPWAIT=0
       # Number of sec to wait before attempting to start tomcat
       - DBWAIT=0
-      # Property names containing periods cannot be modified as env variables
-      # Beware of using spaces in values
-      - JAVA_OPTS=
-        -Ddspace.name=DSpace_Started_with_Docker_Compose
+      # Double underbars in env names will be replaced with periods for apache commons
+      dspace__name=DSpace Started with Docker Compose
     ports:
       - ${PORT:-8080}:8080
     volumes:
       - "assetstore:/dspace/assetstore"
       - "../../add-ons/dspace-docker-tools:/dspace-docker-tools"
+      - "./config-definition.xml:/dspace/config/config-definition.xml"
     entrypoint: /dspace-docker-tools/ingestAIP.sh
     networks:
       - dspacenet

--- a/docker-compose-files/dspace-compose/oracle.override.yml
+++ b/docker-compose-files/dspace-compose/oracle.override.yml
@@ -20,12 +20,12 @@ services:
       # The following overrides will only apply to DSpace 6+
       # If you need to test Oracle with DSpace 4 or 5, you should manually insert these Values
       # into the dspace.cfg file. Consider passing in dspace.cfg as a volume.
-      - JAVA_OPTS=
-        -Ddb.dialect=org.hibernate.dialect.Oracle10gDialect
-        -Ddb.schema=dspace
-        -Ddb.name=oracle
-        -Ddb.driver=oracle.jdbc.OracleDriver
-        -Ddb.url=jdbc:oracle:thin:@//dspacedb:1521/XE
+      # Double underbars in env names will be replaced with periods for apache commons
+      - db__dialect=org.hibernate.dialect.Oracle10gDialect
+      - db__schema=dspace
+      - db__name=oracle
+      - db__driver=oracle.jdbc.OracleDriver
+      - db__url=jdbc:oracle:thin:@//dspacedb:1521/XE
     volumes:
       # export ORADRIVER=<directory containing Oracle JDBC drvier>
       # you must accept the license agreement and download the file from

--- a/docker-compose-files/dspace-compose/rdf.override.yml
+++ b/docker-compose-files/dspace-compose/rdf.override.yml
@@ -4,16 +4,16 @@ version: "3.7"
 services:
   dspace:
     environment:
-      - JAVA_OPTS=
-        -Drdf.contextPath=http://localhost:8080/rdf
-        -Drdf.storage.graphstore.endpoint=http://fuseki:3030/dspace/data
-        -Drdf.public.sparql.endpoint=http://fuseki:3030/dspace/sparql
-        -Drdf.storage.graphstore.authentication=yes
-        -Drdf.storage.graphstore.login=admin
-        -Drdf.storage.graphstore.password=dspace
-        -Drdf.storage.sparql.authentication=yes
-        -Drdf.storage.sparql.login=admin
-        -Drdf.storage.sparql.password=dspace
+     # Double underbars in env names will be replaced with periods for apache commons
+     - rdf__contextPath=http://localhost:8080/rdf
+     - rdf__storage__graphstore__endpoint=http://fuseki:3030/dspace/data
+     - rdf__public__sparql__endpoint=http://fuseki:3030/dspace/sparql
+     - rdf__storage__graphstore__authentication=yes
+     - rdf__storage__graphstore__login=admin
+     - rdf__storage__graphstore__password=dspace
+     - rdf__storage__sparql__authentication=yes
+     - rdf__storage__sparql__login=admin
+     - rdf__storage__sparql__password=dspace
   fuseki:
     image: "stain/jena-fuseki"
     container_name: fuseki


### PR DESCRIPTION
If this change looks good, the config-definition.xml file should be added to the DSpace 6 and DSpace 7 dockerfiles.

Alternative variable passing approach for https://github.com/DSpace-Labs/DSpace-Docker-Images/pull/92