### PR TITLE
Load entities SQL on initial load

### DIFF
--- a/add-ons/dspace-docker-tools/loadEntities.sh
+++ b/add-ons/dspace-docker-tools/loadEntities.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Once this file has been saved to a docker volume, the ingest step will not be re-run
+psql -U dspace < /tmp/dspace.sql

--- a/docker-compose-files/dspace-compose/ComposeFiles.md
+++ b/docker-compose-files/dspace-compose/ComposeFiles.md
@@ -10,6 +10,8 @@
 | d7solr.override.yml | Adds externalized solr to d7.override.yml <br/> Solr http://localhost:8983 |
 | src.override.yml | Optional add-on to trigger and redeploy and tomcat start. |
 | rdf.override.yml | Optional RDF Add-on for DSpace6x and DSpace7x. <br/>http://localhost:3030 |
+| load.entities.yml | Optional config to load the Entities working group test data into DSpace 7 |
+
 
 ## Basic Startup Commands
 _Note: only one compose file should be running at a given time.  

--- a/docker-compose-files/dspace-compose/d7.override.yml
+++ b/docker-compose-files/dspace-compose/d7.override.yml
@@ -11,7 +11,7 @@ services:
       - "solr_statistics:/dspace/solr/statistics/data"
 
   dspace-angular:
-    image: dspace/dspace-angular
+    image: "${ANGULAR_OWNER:-dspace}/dspace-angular:${ANGULAR_VER:-latest}"
     container_name: dspace-angular
     ports:
       - 3000:3000

--- a/docker-compose-files/dspace-compose/load.entities.yml
+++ b/docker-compose-files/dspace-compose/load.entities.yml
@@ -1,0 +1,18 @@
+# suitable for DSpace 6 and 7
+version: "3.7"
+
+services:
+  dspace:
+    environment:
+     # Double underbars in env names will be replaced with periods for apache commons
+     - SKIPAIP=Y
+  dspacedb:
+    volumes:
+      # Download and unzip the entities data file.
+      # This file will be provided by the DSpace Entities Working Group
+      #
+      # export LOADSQL=<local path to the sql file>
+      #
+      # docker-compose -p d7ent -f docker-compose.yml -f d7.override.yml -f load.entities.yml up -d
+      - "${LOADSQL}:/tmp/dspace.sql"
+      - "../../add-ons/dspace-docker-tools/loadEntities.sh:/docker-entrypoint-initdb.d/install-pgcrypto.sh"

--- a/docker-compose-files/dspace-compose/load.entities.yml
+++ b/docker-compose-files/dspace-compose/load.entities.yml
@@ -9,6 +9,8 @@ services:
   dspacedb:
     volumes:
       # Download and unzip the entities data file.
+      # - https://www.dropbox.com/s/ovqp394y3vofnwa/entities7-test-db.sql.gz?dl=1
+      #
       # This file will be provided by the DSpace Entities Working Group
       #
       # export LOADSQL=<local path to the sql file>


### PR DESCRIPTION
## Preparation

- Clone this repository
- Checkout this branch
- Download and unzip the entities SQL
  - https://www.dropbox.com/s/ovqp394y3vofnwa/entities7-test-db.sql.gz?dl=1
- export LOADSQL=<path to the sql file>
- cd to docker-compose-files/dspace-compose

## Run docker-compose to initialize the database

```
DSPACE_VER=entities ANGULAR_VER=entities docker-compose -p d7ent -f docker-compose.yml -f d7.override.yml -f load.entities.yml up -d
```

## Index the Content
Once the services have started up, index the data

```
docker exec -it dspace //dspace/bin/dspace index-discovery
```

## To stop the services

```
docker-compose -p d7ent -f docker-compose.yml -f d7.override.yml -f load.entities.yml down
```

## On subsequent restart, you do not need the load.entities.yml file

```
DSPACE_VER=entities ANGULAR_VER=entities docker-compose -p d7ent -f docker-compose.yml -f d7.override.yml up -d
```

Our recommended Docker installation instructions are here: https://dspace-labs.github.io/DSpace-Docker-Images/documentation/tutorialSetup.html 