### PR TITLE
Ensure changes in ANGULAR_SRC folder sync to Docker Container

### DIFF
--- a/docker-compose-files/dspace-compose/ang-src.override.yml
+++ b/docker-compose-files/dspace-compose/ang-src.override.yml
@@ -10,3 +10,8 @@ services:
     build:
       context: ${ANGULAR_SRC}
       dockerfile: Dockerfile
+    volumes:
+      # Watch the local source directory for changes, and sync to /app on container
+      - "${ANGULAR_SRC}:/app"
+      # However, ensure /app/node_modules on container is NOT synced (from local source)
+      - "/app/node_modules"


### PR DESCRIPTION
Minor change to `ang-src.override.yml` to ensure that any changes to the `$ANGULAR_SRC` folder sync to the Docker Container.  This allows developers to change their local folder, and (within a minute or two) see those changes on the running Docker container.

How to test:
* Ensure you have `$ANGULAR_SRC` defined locally to point at a local checkout of https://github.com/DSpace/dspace-angular
* Build your local checkout as a Docker container: `docker-compose -p d7 -f docker-compose.yml -f d7.override.yml -f load.entities.yml -f ang-src.override.yml build`
* Spin up that container in Docker: `docker-compose -p d7 -f docker-compose.yml -f d7.override.yml -f load.entities.yml -f ang-src.override.yml up -d`
* Now, make a local change to your `$ANGULAR_SRC` folder.  For example, change a font or tweak the color scheme.
* In a minute or two, your Docker container will pick up those changes, and will deploy them to your running container.  You can watch for the changes by running `docker logs dspace-angular -f`

Please note, unfortunately at this time, this only works for the FIRST change (not any further changes) until we merge this related dspace-angular PR: https://github.com/DSpace/dspace-angular/pull/411   Once that related PR is merged, then webpack will pick up any changes and redeploy them to the running Docker container (without needing to restart Docker)