### PR TITLE
Add override for 'preview' branch. 

### DIFF
--- a/docker-compose-files/dspace-compose/d7.preview.yml
+++ b/docker-compose-files/dspace-compose/d7.preview.yml
@@ -1,14 +1,10 @@
 version: "3.7"
 
-# This file adds an externalized Solr service.
-# Once the following PR is merged, this file will replace d7.override.yml
-# https://github.com/DSpace/DSpace/pull/2058/files
-
 services:
   dspace:
-    # TODO: change to static image after preview release is tagged
+    # Image is based on static 'dspace-7.0-preview-1' tag
     image: "dspace/dspace:dspace-7.0-preview-1"
 
   dspace-angular:
-    # TODO: change to static image after preview release is tagged
+    # Image is based on static 'dspace-7.0-preview-1' tag
     image: "dspace/dspace-angular:dspace-7.0-preview-1"

--- a/docker-compose-files/dspace-compose/d7.preview_branch.yml
+++ b/docker-compose-files/dspace-compose/d7.preview_branch.yml
@@ -1,0 +1,10 @@
+version: "3.7"
+
+services:
+  dspace:
+    # This image changes every time the backend "preview" branch is updated
+    image: "dspace/dspace:preview"
+
+  dspace-angular:
+    # This image changes every time the frontend "preview" branch is updated
+    image: "dspace/dspace-angular:preview"


### PR DESCRIPTION
Add a new `d7.preview_branch.yml` to track the `preview` branch of DSpace/DSpace and DSpace/dspace-angular repos.  

Also, update comments in `d7.preview.yml` to make it clear that it runs the (static) `dspace-7.0-preview-1` tagged version of those repos.

This can be tested by running:
`docker-compose -p d7 -f docker-compose.yml -f d7.override.yml -f d7.preview_branch.yml -f load.entities.yml up -d`